### PR TITLE
use only alphabetical characters in country code mask regexp

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const SEPARATORS = [' ', '-', '.', '/'];
 /**
  * Country Code Text Mask.
  */
-const COUNTRY_CODE_MASK = [/\w/, /\w/];
+const COUNTRY_CODE_MASK = [/[A-Za-z]/, /[A-Za-z]/];
 
 /**
  * Generate a flexible VAT Text Mask.


### PR DESCRIPTION
change the country code mask regexp to include only alphabetical characters

fix #8 